### PR TITLE
Fix "clean" to "uninstall"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MISC = categories scalable-max-32
 
 install: $(SUBDIRS) $(EXTRAWORK) $(MISC)
 
-clean:
+uninstall:
 	rm -fr $(DESTDIR)
 
 destdir:


### PR DESCRIPTION
It's a removal command so the target should be `uninstall` rather than `clean`.