### PR TITLE
Add config for Travis CI #83

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+dist: xenial
+sudo: required
+language: generic
+
+branches:
+    - master
+
+addons:
+  apt:
+    packages:
+      - xmlstarlet
+
+script:
+    - make -k test-all


### PR DESCRIPTION
Go to https://travis-ci.com and click "Sign in with GitHub", then open https://travis-ci.org/account/repositories and enable CI for suru-plus repo:

![image](https://user-images.githubusercontent.com/819186/51805492-9868c880-2276-11e9-805b-18499a61e2c0.png)
